### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=BigFont
+version=0.0.0
+author=Jeff Millar
+maintainer=gcassarino
+sentence=Display big digits/numbers on 4 row monochrome text displays.
+paragraph=This library generates a numeric font using 6 special symbols. It implements multiple font sizes: 3x2, 3x3 and 4x4. It was inspired by the GreenHerronEngineering RT-21 rotator controller pictures.
+category=Display
+url=https://github.com/gcassarino/BigFont
+architectures=avr,sam


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files in the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata